### PR TITLE
[Update] Changed Readme Quick deploy Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ this shows how to use netlify with just plain html js and css, together with net
 ## How to use (1 click)
 
 Click this to fork and deploy
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify-labs/vanilla-html-example)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/jchris/public-slack-invite)
 
 ## How to use (manual)
 


### PR DESCRIPTION
Quick deploy link in readme was incorrect. just changed the link to match current repo